### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
   # ログインしているユーザーのみアクセス可能にする（オプション）
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:edit, :update, :show]
-  before_action :authorize_user, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
+  before_action :set_item, only: [:edit, :update, :show, :destroy]
+  before_action :authorize_user, only: [:edit, :update, :destroy]
 
   def edit
   end
@@ -35,6 +35,14 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    if @item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
+  end
+
   private
 
   def set_item
@@ -42,7 +50,7 @@ class ItemsController < ApplicationController
   end
 
   def authorize_user
-    return unless current_user != @item.user
+    return if current_user == @item.user
 
     redirect_to root_path
   end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item), data: { turbo_method: :delete }, data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>
        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
    root 'items#index'
-   resources :items, only: [:new, :create, :index, :show, :edit, :update]
+   resources :items, only: [:new, :create, :index, :show, :edit, :updat, :destroy]
 
 end


### PR DESCRIPTION
## WHAT
- 商品情報の削除機能を実装
- ログインユーザーが自分の商品を削除可能
- 削除後はトップページにリダイレクト

## WHY
- ユーザーが出品後の商品情報を管理できるようにするため
- 誤って出品した商品の取り下げを可能にするため
